### PR TITLE
Refactor server initialization

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,23 +15,35 @@ app.use(express.static(path.join(__dirname, 'public')));
 // In-memory store
 global.activeBills = {}; // example: { txcode123: { amount, phone, status } }
 
-// Load shared JSON data
-global.users = fs.readJsonSync(path.join(__dirname, 'data/users.json'), { throws: false }) || [];
-global.txCodes = fs.readJsonSync(path.join(__dirname, 'data/txcodes.json'), { throws: false }) || [];
-global.teketekeTx = fs.readJsonSync(path.join(__dirname, 'data/teketeke_tx.json'), { throws: false }) || [];
+// Helper to load JSON files asynchronously
+async function loadJson(file) {
+  try {
+    return await fs.readJson(path.join(__dirname, file));
+  } catch (err) {
+    console.error(`Failed to read ${file}:`, err);
+    return [];
+  }
+}
 
-// Load Routes
-require('./routes/login')(app);
-require('./routes/flashpay')(app);
-require('./routes/teketeke')(app);
-require('./routes/pos')(app);
-require('./routes/admin')(app);
-require('./routes/callback')(app);
-require('./routes/dashboard')(app);
-require('./routes/branches')(app);
-require('./routes/cashiers')(app);
-require('./routes/teketeke-admin')(app);
+(async () => {
+  // Load shared JSON data
+  global.users = await loadJson('data/users.json');
+  global.txCodes = await loadJson('data/txcodes.json');
+  global.teketekeTx = await loadJson('data/teketeke_tx.json');
 
-app.listen(PORT, () => {
-  console.log(`🚀 Flash Pay backend running at http://localhost:${PORT}`);
-});
+  // Load Routes
+  require('./routes/login')(app);
+  require('./routes/flashpay')(app);
+  require('./routes/teketeke')(app);
+  require('./routes/pos')(app);
+  require('./routes/admin')(app);
+  require('./routes/callback')(app);
+  require('./routes/dashboard')(app);
+  require('./routes/branches')(app);
+  require('./routes/cashiers')(app);
+  require('./routes/teketeke-admin')(app);
+
+  app.listen(PORT, () => {
+    console.log(`🚀 Flash Pay backend running at http://localhost:${PORT}`);
+  });
+})();


### PR DESCRIPTION
## Summary
- use async `fs.readJson` to load startup JSON files
- catch errors from file reads and default to empty arrays

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684066998924832ba6c914a4794b0b31