### PR TITLE
Secure password hashing

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -1,5 +1,5 @@
 [
-  { "username": "admin", "password": "admin123", "role": "admin" },
-  { "username": "citylink", "password": "1234", "role": "sacco" },
-  { "username": "matatu2345", "password": "5678", "role": "matatu" }
+  { "username": "admin", "password": "0edf86e20715c65753f7391277d8258cfc5c89d8008fc9ad501e3f2fe4b0c8adbab705dcaa13693a23c6a6ff038c7ccecd016fd05a8c483583a307288465f6ae", "salt": "8c0be5c3902d26a13f5db9914d572468", "role": "admin" },
+  { "username": "citylink", "password": "ddda656cb0d84863144875cac1c7aa8988b6306431dcb95244e3a6d25c3252e7ac09ebb120963ae1c8f2d5b74c010e916a5f9f2e1f959871c49fa48a7e179d79", "salt": "8203358a77f9362c9c55a1a522ccdecb", "role": "sacco" },
+  { "username": "matatu2345", "password": "23edf305b62029165f170335403339c34a92118fb9288fc95fbd870287930b860e58c35548f4a32af1dd3528509890e7961ad92845861ab21d60a2f7d5ab4172", "salt": "113217f6576843c882e305bebd658a71", "role": "matatu" }
 ]

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const crypto = require('crypto');
 
 const usersFile = path.join(__dirname, '../data/users.json');
 
@@ -23,7 +24,9 @@ module.exports = function (app) {
       return res.status(409).json({ success: false, message: 'Username already exists' });
     }
 
-    const newUser = { username, password, role };
+    const salt = crypto.randomBytes(16).toString('hex');
+    const hashed = crypto.scryptSync(password, salt, 64).toString('hex');
+    const newUser = { username, password: hashed, salt, role };
     global.users.push(newUser);
     fs.writeJson(usersFile, global.users, { spaces: 2 });
 

--- a/routes/login.js
+++ b/routes/login.js
@@ -1,13 +1,21 @@
 // routes/login.js
 
 const path = require('path');
+const crypto = require('crypto');
 
 module.exports = function (app) {
   app.post('/login', (req, res) => {
     const { username, password } = req.body;
-    const user = global.users.find(u => u.username === username && u.password === password);
+    const user = global.users.find(u => u.username === username);
 
-    if (!user) return res.status(401).json({ success: false, message: 'Invalid credentials' });
+    if (!user) {
+      return res.status(401).json({ success: false, message: 'Invalid credentials' });
+    }
+
+    const hashed = crypto.scryptSync(password, user.salt, 64).toString('hex');
+    if (hashed !== user.password) {
+      return res.status(401).json({ success: false, message: 'Invalid credentials' });
+    }
 
     res.json({ success: true, role: user.role, redirect: getRedirect(user.role) });
   });


### PR DESCRIPTION
## Summary
- hash passwords when adding users with Node's crypto scrypt
- validate hashed passwords during login
- update default users with hashed passwords and salts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840669babec832b9c9a040d5932c911